### PR TITLE
feat:  user id as JWT tokens subject

### DIFF
--- a/back/src/main/java/com/openclassrooms/mdd/repository/UserRepository.java
+++ b/back/src/main/java/com/openclassrooms/mdd/repository/UserRepository.java
@@ -17,4 +17,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByEmail(String email);
     Optional<User> findByUserName(String userName);
+    Optional<User> findById(int id);
 }

--- a/back/src/main/java/com/openclassrooms/mdd/security/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/com/openclassrooms/mdd/security/jwt/JwtAuthenticationFilter.java
@@ -69,11 +69,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // extract JWT Token and included email and try to authenticate the user
             JwtToken jwtToken = token.get();
-            String userEmail = jwtToken.getClaims().getSubject();
-            log.info("User email: {}", userEmail);
+            String userId = jwtToken.getClaims().getSubject();
+            log.info("User id: {}", userId);
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (userEmail != null && authentication == null) {
-                UserDetails userDetails = this.customUserDetailsService.loadUserByUsername(userEmail);
+            if (userId != null && authentication == null) {
+                UserDetails userDetails = this.customUserDetailsService.loadUserByUsername(userId);
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                         userDetails,
                         null,

--- a/back/src/main/java/com/openclassrooms/mdd/security/service/CustomUserDetailsService.java
+++ b/back/src/main/java/com/openclassrooms/mdd/security/service/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.openclassrooms.mdd.security.service;
 
 import com.openclassrooms.mdd.model.User;
 import com.openclassrooms.mdd.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
  * Time:15:58
  */
 @Service
+@Slf4j
 public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
@@ -22,9 +24,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User foundUser = userRepository.findByEmail(username).orElseThrow(() -> new UsernameNotFoundException(username));
-
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, NumberFormatException {
+        log.info("Loading User details for  {}", username);
+        User foundUser = userRepository.findById(Integer.parseInt(username)).orElseThrow(() -> new UsernameNotFoundException(username));
+        log.info("User details service got {}", foundUser);
         return new UserDetailsImpl(foundUser.getId(), foundUser.getEmail(), foundUser.getPassword());
     }
 }

--- a/back/src/main/java/com/openclassrooms/mdd/security/service/JwtService.java
+++ b/back/src/main/java/com/openclassrooms/mdd/security/service/JwtService.java
@@ -72,10 +72,10 @@ public class JwtService {
     }
 
     public String generateToken(User user) {
-        log.info("Generating JWT token for user {}", user.getEmail());
+        log.info("Generating JWT token for user {} {}", user.getEmail(), user.getId());
         return Jwts
                 .builder()
-                .subject(user.getEmail())
+                .subject(String.valueOf(user.getId()))
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + jwtExpiration))
                 .signWith(getSignInKey())

--- a/back/src/main/java/com/openclassrooms/mdd/service/UserServiceImpl.java
+++ b/back/src/main/java/com/openclassrooms/mdd/service/UserServiceImpl.java
@@ -126,6 +126,7 @@ public class UserServiceImpl implements UserService {
     public User authenticateUser(String email, String password) throws AuthenticationException {
         Optional<User> user = findUserByEmail(email);
         if(user.isEmpty()) {
+            log.info("User not found");
             throw new AuthenticationException("User not found") {
                 @Override
                 public String getMessage() {
@@ -133,8 +134,9 @@ public class UserServiceImpl implements UserService {
                 }
             };
         }
+        log.info("User has been found, let's pass to authenticationManager");
         authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(email, password)
+                new UsernamePasswordAuthenticationToken(user.get().getId(), password)
         );
         return user.get();
     }

--- a/back/src/test/java/com/openclassrooms/mdd/controller/AuthControllerIT.java
+++ b/back/src/test/java/com/openclassrooms/mdd/controller/AuthControllerIT.java
@@ -105,6 +105,7 @@ public class AuthControllerIT {
                     .setUserName("testuser");
 
             when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+            when(userRepository.findById(1)).thenReturn(Optional.of(user));
             when(refreshTokenRepository.save(any(RefreshToken.class))).thenAnswer(i -> i.getArgument(0));
 
             MvcResult result = mockMvc.perform(post(LOGIN_URL).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(loginRequest)))

--- a/back/src/test/java/com/openclassrooms/mdd/controller/UserControllerIT.java
+++ b/back/src/test/java/com/openclassrooms/mdd/controller/UserControllerIT.java
@@ -4,7 +4,6 @@ package com.openclassrooms.mdd.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openclassrooms.mdd.dto.request.UpdateUserDto;
-import com.openclassrooms.mdd.dto.response.JwtResponse;
 import com.openclassrooms.mdd.dto.response.SubscriptionDto;
 import com.openclassrooms.mdd.dto.response.UserDto;
 import com.openclassrooms.mdd.model.RefreshToken;
@@ -29,7 +28,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -188,7 +186,7 @@ public class UserControllerIT {
 
         @Test
         @WithMockUser(username = "test@example.com")
-        public void shouldReturnJwtResponseWhenUserUpdated() throws Exception {
+        public void shouldReturnUserDtoWhenUserUpdated() throws Exception {
             User user = new User().setId(1).setUserName("username").setEmail("test@example.com");
 
             UpdateUserDto updateUserDto = new UpdateUserDto();
@@ -210,11 +208,9 @@ public class UserControllerIT {
                     .andExpect(status().isOk())
                     .andReturn();
 
-            JwtResponse jwtResponse = objectMapper.readValue(responseUser.getResponse().getContentAsString(), JwtResponse.class);
-            assertThat(jwtResponse.getToken()).isNotEmpty();
-            assertThat(jwtResponse.getUsername()).isEqualTo("otherusername");
-            assertThat(jwtResponse.getRefreshToken()).isNotEmpty();
-            assertThat(jwtResponse.getId()).isEqualTo(1);
+            UserDto responseUserDto = objectMapper.readValue(responseUser.getResponse().getContentAsString(), UserDto.class);
+            assertThat(responseUserDto.getEmail()).isEqualTo("othertest@example.com");
+            assertThat(responseUserDto.getUserName()).isEqualTo("otherusername");
         }
     }
     @Nested

--- a/back/src/test/java/com/openclassrooms/mdd/controller/UserControllerTest.java
+++ b/back/src/test/java/com/openclassrooms/mdd/controller/UserControllerTest.java
@@ -1,18 +1,14 @@
 package com.openclassrooms.mdd.controller;
 
 import com.openclassrooms.mdd.dto.request.UpdateUserDto;
-import com.openclassrooms.mdd.dto.response.JwtResponse;
 import com.openclassrooms.mdd.dto.response.SubscriptionDto;
 import com.openclassrooms.mdd.dto.response.TopicDto;
 import com.openclassrooms.mdd.dto.response.UserDto;
 import com.openclassrooms.mdd.mapper.SubscriptionMapper;
 import com.openclassrooms.mdd.mapper.UserMapper;
-import com.openclassrooms.mdd.model.RefreshToken;
 import com.openclassrooms.mdd.model.Subscription;
 import com.openclassrooms.mdd.model.Topic;
 import com.openclassrooms.mdd.model.User;
-import com.openclassrooms.mdd.security.service.JwtService;
-import com.openclassrooms.mdd.security.service.RefreshTokenService;
 import com.openclassrooms.mdd.service.UserService;
 import jakarta.persistence.EntityExistsException;
 import org.junit.jupiter.api.Nested;
@@ -49,12 +45,6 @@ public class UserControllerTest {
 
     @Mock
     private UserService userService;
-
-    @Mock
-    private JwtService jwtService;
-
-    @Mock
-    private RefreshTokenService refreshTokenService;
 
     @Mock
     private UserMapper userMapper;
@@ -158,24 +148,25 @@ public class UserControllerTest {
             User user = new User();
             User updateUser = new User();
             Principal principal = mock(Principal.class);
+            UserDto userDto = new UserDto();
+            userDto.setId(1);
+            userDto.setUserName("othertestuser");
+            userDto.setEmail("testother@example.com");
 
             when(principal.getName()).thenReturn("test@example.com");
             when(userMapper.updateUserDtoToUser(requestUserUpdate)).thenReturn(updateUser);
             when(userService.findUserByEmail("test@example.com")).thenReturn(Optional.of(user));
             when(userService.updateUser(user, updateUser)).thenReturn(user);
-            when(jwtService.generateToken(user)).thenReturn("jwt_token");
-            when(refreshTokenService.getOrCreateRefreshToken(user)).thenReturn(new RefreshToken().setId(1).setToken("refresh_token"));
+            when(userMapper.userToUserDto(user)).thenReturn(userDto);
 
-            JwtResponse jwtResponse = userController.update(requestUserUpdate, principal);
+            UserDto responseUserDto = userController.update(requestUserUpdate, principal);
 
             verify(userMapper).updateUserDtoToUser(requestUserUpdate);
             verify(userService).findUserByEmail("test@example.com");
             verify(userService).updateUser(user, updateUser);
-            verify(jwtService).generateToken(user);
-            verify(refreshTokenService).getOrCreateRefreshToken(user);
+            verify(userMapper).userToUserDto(user);
 
-            assertThat(jwtResponse.getToken()).isEqualTo("jwt_token");
-            assertThat(jwtResponse.getRefreshToken()).isEqualTo("refresh_token");
+            assertThat(responseUserDto).isEqualTo(userDto);
         }
     }
 

--- a/back/src/test/java/com/openclassrooms/mdd/security/jwt/JwtAuthenticationFilterTest.java
+++ b/back/src/test/java/com/openclassrooms/mdd/security/jwt/JwtAuthenticationFilterTest.java
@@ -117,9 +117,10 @@ public class JwtAuthenticationFilterTest {
 
     @Test
     public void shouldAuthenticateUser() throws Exception {
-        when(customUserDetailsService.loadUserByUsername("test@example.com")).thenReturn(new User("test@example.com", "password", Collections.emptyList()));
-        Claims claims = Jwts.claims().subject("test@example.com").build();
-        JwtToken jwtToken = new JwtToken("test@example.com", claims);
+        when(customUserDetailsService.loadUserByUsername("1")).thenReturn(new User("1", "password", Collections.emptyList()));
+
+        Claims claims = Jwts.claims().subject("1").build();
+        JwtToken jwtToken = new JwtToken("1", claims);
         when(jwtService.extractTokenFromRequest(request)).thenReturn(Optional.of(jwtToken));
 
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -130,8 +131,8 @@ public class JwtAuthenticationFilterTest {
 
     @Test
     public void shouldNotAuthenticateUserWhenAuthenticationNotNull() throws Exception {
-        Claims claims = Jwts.claims().subject("test@example.com").build();
-        JwtToken jwtToken = new JwtToken("test@example.com", claims);
+        Claims claims = Jwts.claims().subject("1").build();
+        JwtToken jwtToken = new JwtToken("1", claims);
         when(jwtService.extractTokenFromRequest(request)).thenReturn(Optional.of(jwtToken));
 
         SecurityContextHolder.getContext().setAuthentication(new Authentication() {
@@ -180,7 +181,7 @@ public class JwtAuthenticationFilterTest {
     @Test
     public void shouldNotAuthenticateUserWhenUserNotFoundInClaims() throws Exception {
         Claims claims = Jwts.claims().subject(null).build();
-        JwtToken jwtToken = new JwtToken("test@example.com", claims);
+        JwtToken jwtToken = new JwtToken("", claims);
         when(jwtService.extractTokenFromRequest(request)).thenReturn(Optional.of(jwtToken));
 
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);

--- a/back/src/test/java/com/openclassrooms/mdd/security/service/CustomUserDetailsServiceTest.java
+++ b/back/src/test/java/com/openclassrooms/mdd/security/service/CustomUserDetailsServiceTest.java
@@ -33,10 +33,15 @@ public class CustomUserDetailsServiceTest {
     private CustomUserDetailsService customUserDetailsService;
 
     @Test
+    public void shouldThrowNumberFormatExceptionWHenUserNotFound() {
+        assertThrows(NumberFormatException.class, () -> customUserDetailsService.loadUserByUsername("test@example.com"));
+    }
+
+    @Test
     public void shouldThrowUsernameNotFoundExceptionWHenUserNotFound() {
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
-        assertThrows(UsernameNotFoundException.class, () -> customUserDetailsService.loadUserByUsername("test@example.com"));
-        verify(userRepository).findByEmail("test@example.com");
+        when(userRepository.findById(1)).thenReturn(Optional.empty());
+        assertThrows(UsernameNotFoundException.class, () -> customUserDetailsService.loadUserByUsername("1"));
+        verify(userRepository).findById(1);
     }
 
     @Test
@@ -47,9 +52,9 @@ public class CustomUserDetailsServiceTest {
                 .setUserName("Username")
                 .setPassword("password");
 
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findById(1)).thenReturn(Optional.of(user));
 
-        UserDetailsImpl userDetails = (UserDetailsImpl) customUserDetailsService.loadUserByUsername("test@example.com");
+        UserDetailsImpl userDetails = (UserDetailsImpl) customUserDetailsService.loadUserByUsername("1");
 
         assertThat(userDetails).isNotNull();
         assertThat(userDetails.getId()).isEqualTo(1L);

--- a/back/src/test/java/com/openclassrooms/mdd/security/service/JwtServiceTest.java
+++ b/back/src/test/java/com/openclassrooms/mdd/security/service/JwtServiceTest.java
@@ -166,8 +166,8 @@ public class JwtServiceTest {
 
             assertThat(token).isNotBlank();
             assertThat(jwtToken).isPresent();
-            assertThat(jwtToken.get().getSubject()).isEqualTo("test@example.com");
-            assertThat(jwtToken.get().getClaims().getSubject()).isEqualTo("test@example.com");
+            assertThat(jwtToken.get().getSubject()).isEqualTo("1");
+            assertThat(jwtToken.get().getClaims().getSubject()).isEqualTo("1");
         }
     }
 }

--- a/front/src/app/core/services/current-user.service.ts
+++ b/front/src/app/core/services/current-user.service.ts
@@ -1,10 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, map, Observable, of, shareReplay, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, map, Observable, of, shareReplay, switchMap } from 'rxjs';
 import { User } from '../models/user.interface';
 import { Subscription } from '../models/subscription.interface';
 import { UpdateUserRequest } from '../models/update-user-request';
-import { SessionInformation } from '../models/sessionInformation.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -38,13 +37,13 @@ export class CurrentUserService {
     );
   }
 
-  public updateCurrentUser(updateUserRequest: UpdateUserRequest): Observable<SessionInformation> {
+  public updateCurrentUser(updateUserRequest: UpdateUserRequest): Observable<User> {
     // load from backend otherwise
-    return this.httpClient.put<SessionInformation>(`${this.apiPath}/me`, updateUserRequest).pipe(
-      /*switchMap((sessionInfo: SessionInformation) => {
-        this.user$.next(null); // reset BehaviorSubject
-        return of(sessionInfo);
-      })*/
+    return this.httpClient.put<User>(`${this.apiPath}/me`, updateUserRequest).pipe(
+      switchMap((updatedUser: User) => {
+        this.user$.next(updatedUser); // reset BehaviorSubject
+        return of(updatedUser);
+      })
     );
   }
 

--- a/front/src/app/features/me/me.component.ts
+++ b/front/src/app/features/me/me.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CurrentUserService } from '../../core/services/current-user.service';
 import { User } from '../../core/models/user.interface';
-import { BehaviorSubject, map, Observable, take, tap } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
 import { TopicComponent } from '../topics/list/topic/topic.component';
 import { Subscription } from '../../core/models/subscription.interface';
@@ -10,11 +10,8 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { UpdateUserRequest } from '../../core/models/update-user-request';
-import { SessionService } from '../../core/services/session.service';
-import { SessionInformation } from '../../core/models/sessionInformation.interface';
 
 @Component({
   selector: 'app-me',
@@ -38,20 +35,10 @@ export class MeComponent implements OnInit{
   public subscriptions$!: Observable<Subscription[]>;
   public form!: FormGroup;
 
-  constructor(private userService: CurrentUserService, private fb: FormBuilder, private sessionService:SessionService) {
-    
-  }
+  constructor(private userService: CurrentUserService, private fb: FormBuilder) {}
 
   public updateCurrentUser() :void {
-    this.userService.updateCurrentUser(this.form.value as UpdateUserRequest).subscribe({
-      next: (sessionInfo: SessionInformation) => {
-        console.log('new session info with token '+sessionInfo.token);
-        this.sessionService.logIn(sessionInfo);
-        this.userService.logout();
-        console.log('getting new /me');
-        this.userService.getCurrentUser().pipe(take(1)).subscribe();
-      }
-    });
+    this.userService.updateCurrentUser(this.form.value as UpdateUserRequest).subscribe();
   }
 
   public onUnsubscribe(topicId: number) :void {


### PR DESCRIPTION
Immutable user id is now used as subject in JWT tokens to allow email edition without breaking JWT tokens or needing to add JWT regeneration logic.