### PR TITLE
feature/front-posts-caching

### DIFF
--- a/front/angular.json
+++ b/front/angular.json
@@ -57,7 +57,13 @@
             "development": {
               "optimization": false,
               "extractLicenses": false,
-              "sourceMap": true
+              "sourceMap": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/front/src/app/core/services/current-user.service.ts
+++ b/front/src/app/core/services/current-user.service.ts
@@ -4,6 +4,8 @@ import { BehaviorSubject, map, Observable, of, shareReplay, switchMap } from 'rx
 import { User } from '../models/user.interface';
 import { Subscription } from '../models/subscription.interface';
 import { UpdateUserRequest } from '../models/update-user-request';
+import { PostService } from './post.service';
+import { Post } from '../models/post.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -14,7 +16,7 @@ export class CurrentUserService {
 
   private user$: BehaviorSubject<User | null> = new BehaviorSubject<User |null>(null);
   private userSubscriptions$: BehaviorSubject<Subscription[] |null> = new BehaviorSubject<Subscription[] |null>(null);
-
+  
   constructor(private httpClient: HttpClient) { }
 
   public getCurrentUser() : Observable<User>{

--- a/front/src/app/core/services/post.service.ts
+++ b/front/src/app/core/services/post.service.ts
@@ -1,3 +1,4 @@
+import { environment } from '../../../environments/environment';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, map, Observable, of, shareReplay, switchMap, tap } from 'rxjs';
 import { Post } from '../models/post.interface';
@@ -67,8 +68,7 @@ export class PostService {
   }
 
   public shouldReload(): boolean {
-    console.log('shouldReload ? ('+new Date().getTime()+'-'+this.cachedAt+') = '+(new Date().getTime() - this.cachedAt > 60000));
-    return new Date().getTime() - this.cachedAt > 60000;
+    return new Date().getTime() - this.cachedAt > environment.postServiceCacheMaxAgeMs;
   }
 
   getAllPosts(sortData?: PostSort): Observable<Post[]> {    

--- a/front/src/app/core/services/post.service.ts
+++ b/front/src/app/core/services/post.service.ts
@@ -19,6 +19,7 @@ export class PostService {
   private cachedAt: number = 0;
   
   constructor(private httpClient: HttpClient, private userService: CurrentUserService) {
+    // locally cache current user subscriptions when they get updated
     this.userService.getCurrentUserSubscriptions().pipe(tap((s) => {
       this.clearCache(); 
       this.subscriptions = s

--- a/front/src/environments/environment.development.ts
+++ b/front/src/environments/environment.development.ts
@@ -1,0 +1,3 @@
+export const environment = {
+    postServiceCacheMaxAgeMs: 60000 // 1 minute before posts reloading
+};

--- a/front/src/environments/environment.ts
+++ b/front/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+    postServiceCacheMaxAgeMs: 600000 // 10 minutes before posts reloading
+};


### PR DESCRIPTION
Attempt at limiting API requests for posts especially : 
- posts are fully reloaded only when local cache expires (configurable in environments with configuration variable postServiceCacheMaxAgeMs)
- postService now handles a local copy of current user subscriptions to filter posts to display without having to fully reload every time the current user changes their subscription